### PR TITLE
HADOOP-17230. Fix JAVA_HOME with spaces

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/conf/hadoop-env.cmd
+++ b/hadoop-common-project/hadoop-common/src/main/conf/hadoop-env.cmd
@@ -24,6 +24,9 @@
 @rem The java implementation to use.  Required.
 set JAVA_HOME=%JAVA_HOME%
 
+@rem In case path contains spaces, convert JAVA_HOME to short paths
+for %%I in ("%JAVA_HOME%") do set JAVA_HOME=%%~sI
+
 @rem The jsvc implementation to use. Jsvc is required to run secure datanodes.
 @rem set JSVC_HOME=%JSVC_HOME%
 


### PR DESCRIPTION
Added line to convert %JAVA_HOME% to short paths, in case the installation directory contains a space. Current installers suggest using \Program Files\Java, so everyone using Windows keeps running into problems trying to launch Hadoop.

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
